### PR TITLE
feat: http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpx"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [[bin]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY ./Cargo.* ./
 COPY ./.cargo/vendor ./.cargo/config.toml
 COPY ./src ./src 
 COPY ./vendor ./vendor 
+COPY ./Readme.md ./Readme.md
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER=arm-linux-gnueabihf-ld
 ENV TARGET_CC=arm-linux-gnueabihf-gcc

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -15,7 +15,7 @@ use trust_dns_resolver::{
 use crate::config::Config;
 
 #[derive(Debug)]
-/// Handle to background DNS resolver task. 
+/// Handle to background DNS resolver task.
 pub struct Resolver<S> {
     state: S,
 }
@@ -41,7 +41,7 @@ impl Clone for Resolver<Running> {
 
 impl Resolver<Running> {
     #[instrument]
-    /// Resolves hostname from SNI to remote address. 
+    /// Resolves hostname from SNI to remote address.
     pub async fn resolve(
         &self,
         host: String,
@@ -180,4 +180,3 @@ fn start_background_resolver(config: &Config) -> Result<TokioAsyncResolver, anyh
     TokioAsyncResolver::tokio(resolver_config, resolver_opts)
         .map_err(|err| anyhow::anyhow!("{err}"))
 }
-

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,76 @@
+use anyhow::Error;
+use bytes::BufMut;
+use rustls::internal::msgs::message::OpaqueMessage;
+use tokio::io::AsyncReadExt;
+use tracing::{debug, error, instrument};
+
+const GET: &[u8] = b"GET";
+const HEAD: &[u8] = b"HEAD";
+const OPTIONS: &[u8] = b"OPTIONS";
+const CONNECT: &[u8] = b"CONNECT";
+const POST: &[u8] = b"POST";
+const PUT: &[u8] = b"PUT";
+const PATCH: &[u8] = b"PATCH";
+const TRACE: &[u8] = b"TRACE";
+const DELETE: &[u8] = b"DELETE";
+const METHODS: [&[u8]; 9] = [GET, HEAD, OPTIONS, CONNECT, POST, PUT, PATCH, TRACE, DELETE];
+
+#[instrument]
+pub fn is_http(buf: &[u8]) -> bool {
+    debug!("Got buf: {}", buf.len());
+    METHODS.iter().any(|&method| {
+        debug!("Method: {method:?}");
+        buf.starts_with(method)
+    })
+}
+
+#[instrument]
+fn try_read_hostname(buf: &[u8]) -> Option<String> {
+    buf.as_ref()
+        .split(|byte| *byte == b'\n')
+        .filter_map(|line| std::str::from_utf8(line).ok())
+        .find(|line| {
+            debug!("Got a line: {line}");
+            line.starts_with("Host") || line.starts_with("host")
+        })
+        .and_then(|header| header.split(':').nth(1))
+        .map(|hostname| hostname.trim())
+        .map(ToOwned::to_owned)
+}
+
+#[instrument]
+pub async fn read_hostname<B, R>(buf: &mut B, reader: &mut R) -> Result<String, Error>
+where
+    R: AsyncReadExt + Unpin + core::fmt::Debug,
+    B: BufMut + AsRef<[u8]> + core::fmt::Debug,
+{
+    debug!("Entered");
+    if let Some(hostname) = try_read_hostname(buf.as_ref()) {
+        return Ok(hostname);
+    }
+    debug!("Reading more");
+    let mut total = buf.as_ref().len();
+    loop {
+        let read = reader.read_buf(buf).await?;
+        debug!("Read: {read}/{total}");
+        if read == 0 {
+            return Err(anyhow::anyhow!("EOF, but failed to read hostname"));
+        } else {
+            total += read;
+        }
+
+        match try_read_hostname(buf.as_ref()) {
+            Some(hostname) => {
+                debug!("Got hostname after reading {total} bytes -> {hostname}");
+                return Ok(hostname);
+            }
+            None if total > OpaqueMessage::MAX_WIRE_SIZE => {
+                error!("Buf exceeded max size");
+                return Err(anyhow::anyhow!("Buf exceeded max size"));
+            }
+            None => {
+                debug!("Read {total} bytes, no hostname yet");
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,16 @@
 
 pub mod config;
 pub mod dns;
-pub mod sni;
+pub mod http;
+pub mod tls;
 
-use bytes::BytesMut;
+use std::time::Duration;
+
+use anyhow::Error;
+use bytes::{BufMut, BytesMut};
 use dns::{Resolver, Running};
-use sni::read_sni;
 use tokio::{
-    io::{self, AsyncWriteExt},
+    io::{self, AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
 };
 use tracing::{debug, instrument, warn};
@@ -23,14 +26,25 @@ pub async fn forward(
     debug!("Got port from incoming connection: {port}");
 
     let mut buf = BytesMut::with_capacity(256);
-    let outgoing = match read_sni(&mut buf, incoming).await {
-        Err(err) => {
-            warn!("Failed to resolve sni: {err}, falling back to default destination");
+
+    let with_deadline = {
+        let duration = Duration::from_secs(30);
+        tokio::time::timeout(duration, read_name(&mut buf, incoming))
+    };
+
+    let outgoing = match with_deadline.await {
+        Err(_) => {
+            debug!("Failed to resolve service name in time");
+            incoming.shutdown().await?;
+            return Ok(());
+        }
+        Ok(Err(err)) => {
+            warn!("Failed to resolve service name: {err}, falling back to default destination");
             resolver.default_destination().await
         }
-        Ok(sni) => {
-            debug!(host = sni.as_str(), "resolved  sni");
-            resolver.resolve(sni, port).await
+        Ok(Ok(name)) => {
+            debug!(host = name.as_str(), "resolved  sni");
+            resolver.resolve(name, port).await
         }
     }?;
 
@@ -50,4 +64,27 @@ pub async fn forward(
 
     debug!(incoming, outgoing, "After copy_bidirectional");
     Ok(())
+}
+
+#[instrument]
+pub async fn read_name<B, R>(buf: &mut B, reader: &mut R) -> Result<String, Error>
+where
+    R: AsyncReadExt + Unpin + core::fmt::Debug,
+    B: BufMut + AsRef<[u8]> + core::fmt::Debug,
+{
+    let mut read = 0;
+    loop {
+        read += reader.read_buf(buf).await?;
+        if read >= 10 {
+            break;
+        }
+    }
+
+    if http::is_http(&buf.as_ref()[..10]) {
+        debug!("reading hostname");
+        http::read_hostname(buf, reader).await
+    } else {
+        debug!("reading sni");
+        tls::read_sni(buf, reader).await
+    }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,6 +1,5 @@
-//! To route by SNI, this field needs to be parsed from TLS handshake. 
+//! To route by SNI, this field needs to be parsed from TLS handshake.
 //! To avoid reinventing wheels - module leverages [`rustls`].
-//!
 use anyhow::Error;
 use bytes::BufMut;
 use rustls::{internal::msgs::message::OpaqueMessage, server::Acceptor};
@@ -9,7 +8,8 @@ use tokio::io::AsyncReadExt;
 use tracing::{debug, error, instrument, trace};
 
 #[instrument]
-/// Collects incoming data from [`tokio::io::AsyncReadExt`] into [`bytes::BufMut`], feeding each read into [`rustls::server::Acceptor`]
+/// Collects incoming data from [`tokio::io::AsyncReadExt`] into [`bytes::BufMut`],
+/// feeding reads to [`rustls::server::Acceptor`].
 /// until SNI value is readable from TLS handshake or MAX_WIRE_SIZE exceeded.
 pub async fn read_sni<B, R>(buf: &mut B, reader: &mut R) -> Result<String, Error>
 where


### PR DESCRIPTION
Adds support for http Hostname header parsing
- Rename `read_sni` into `read_name`
- Split `read_name` into `read_hostname` and `read_sni`
- rename `sni` module to `tls`
- add `http` module
- Add 30 second timeout for `read_name`