### PR TITLE
fix: dns-resolver

### DIFF
--- a/ormos/Cargo.toml
+++ b/ormos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormos"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 

--- a/ormos/src/config/listener.rs
+++ b/ormos/src/config/listener.rs
@@ -6,8 +6,8 @@ const DEFAULT_BIND: &str = "127.0.0.1:8314";
 
 /// Configuration for a single listener.
 ///
-/// Listeners consist of bind address and collection of 
-/// incoming traffic parsers to apply. 
+/// Listeners consist of bind address and collection of
+/// incoming traffic parsers to apply.
 #[derive(Deserialize, Debug, PartialEq)]
 pub struct Listener {
     pub address: SocketAddr,


### PR DESCRIPTION
Use SRV records target value for an additional ip lookup. Previous implementation
relied on the ip iterator consistency which is
not always there