### PR TITLE
chore: update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "ormos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
 	"ormos",
 ]
 
+resolver = "2"
+
 [workspace.package]
 authors = [
 	"Lainera <fistlain@hotmail.com>",


### PR DESCRIPTION
- Bump version in Cargo.lock
- Explicitly use resolver v2